### PR TITLE
Fix Importing Frontend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 description = "A yt frontend for libyt"
 readme = "README.md"
+license = {file = "LICENSE"}
 requires-python = ">=3.7"
 dependencies = ["yt"]
 keywords = ["yt_libyt"]
@@ -19,6 +20,9 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python :: 3"
 ]
+
+[tool.setuptools]
+license-files = ["LICENSE"]
 
 [tool.setuptools.dynamic]
 version = {attr = "yt_libyt._version.__version__"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,6 @@
 [metadata]
 long_description = file: README.md
 long_description_content_type = text/markdown
-license = BSD
-license_files = LICENSE
 
 [options]
 include_package_data = True

--- a/yt_libyt/data_structures.py
+++ b/yt_libyt/data_structures.py
@@ -182,8 +182,12 @@ class libytDataset(Dataset):
         for name in yt.frontends.api._frontends:
             if self._code_frontend == name.lower():
                 # Import frontend dataset
+                # The naming rule of dataset class is XXXDataset, XXX doesn't necessarily need to be all capital
                 frontend = importlib.import_module(f"yt.frontends.{name.lower()}.api")
-                frontend_dataset = getattr(frontend, f"{name.upper()}Dataset")
+                frontend_dataset = None
+                for _ in dir(frontend):
+                    if _.endswith("Dataset"):
+                        frontend_dataset = getattr(frontend, _)
 
                 # Borrow frontend's field info
                 self._field_info_class = frontend_dataset._field_info_class


### PR DESCRIPTION
This is a bug introduced in the last PR. Since frontend named their dataset class `XXXDataset` with `XXX` not necessarily be all capital, this makes `yt_libyt` unable to import some of the frontend, like `Enzo`.
(Should definitely improve the test on how to integrate `libyt` + `yt_libyt` + `yt` + simulation code together)

This PR also moved license info from `setup.cfg` to `pyproject.toml`.